### PR TITLE
fix: remove timeout in e2e

### DIFF
--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -8,11 +8,6 @@ on:
         default: "14.x"
         required: false
         type: string
-      e2e-timeout:
-        description: "Timeout in minutes"
-        default: 20
-        required: false
-        type: number
       retries:
         description: "Number of retries"
         default: 2


### PR DESCRIPTION
https://github.com/mindbox-cloud/frontend/actions/runs/4302686403
падают е2е с таймаутом