### PR TITLE
Add helmfile-validate action

### DIFF
--- a/helmfile-validate/action.yml
+++ b/helmfile-validate/action.yml
@@ -1,0 +1,24 @@
+name: Helmfile validate
+description: Validates helmfile releases
+inputs:
+  path:
+    description: Path to helmfile.yaml
+    required: false
+    default: helmfile/helmfile.yaml
+  environment:
+    description: Helmfile environment
+    required: true
+
+outputs: {}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup helmfile
+      uses: mamezou-tech/setup-helmfile@v1.0.0
+
+    - name: Helmfile lint
+      run: helmfile -f ${{ inputs.path }} --environment ${{ inputs.environment }} lint --args "--strict --quiet"
+
+    - name: Helmfile template
+      run: helmfile -f ${{ inputs.path }} --environment ${{ inputs.environment }} template


### PR DESCRIPTION
https://github.com/mindbox-cloud/issues-platform/issues/374

Добавляю простенький action для валидации helmfile.

- lint валидирует по жесткому
- template для того, чтобы подсмотреть результат рендеринга

Вызывается для каждого окружения, которое нужно отвалидировать. Авторизацию в registry не стал сюда заносить, чтобы не перегружать переменными. Для всех окружений вместе тоже не стал делать, - так смотреть результат неудобно, ну и вообще такого из коробки нет, нужно работать.