### PR TITLE
fix(frontend_ci): reduces max number of workers for unit tests

### DIFF
--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Run tests
         if: ${{ inputs.tests }}
-        run: npm run test
+        run: npm run test -- --maxConcurrency=1 --maxWorkers=1
 
       - name: Install E2E deps
         if: ${{ inputs.e2e_typechecking || inputs.e2e_linters }}


### PR DESCRIPTION
Хочу глобально уменьшить кол-во воркеров для юнит-тестов.
Можно, конечно, локально уменьшить в скрипте `npm run test`, но этот скрипт запускается так же локально перед пушем и локально хочется чтобы тесты гонялись быстрее. В CI есть проблема с 4 воркерами, поэтому ограничение нужно только в CI.