### PR TITLE
truncate plan to 30k

### DIFF
--- a/yc-terraform-ci/action.yml
+++ b/yc-terraform-ci/action.yml
@@ -171,7 +171,7 @@ runs:
         original_length=${#plan}
         if (($original_length > 65536)); then truncated=true; else truncated=false; fi
         echo "truncated=${truncated}" >> $GITHUB_OUTPUT
-        echo "${plan:0:65536}"
+        echo "${plan:0:31000}"
       working-directory: ${{ inputs.workingDir }}
       shell: bash
 


### PR DESCRIPTION
Прочитал, что енвы имеют лимит длины в 31-32к.