### PR TITLE
fix: fix timeouts for step retry

### DIFF
--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -376,7 +376,7 @@ jobs:
         if: ${{ inputs.use_k8_deploy_process && inputs.retry_push_to_registry }}
         uses: nick-fields/retry@v2
         with:
-          timeout_seconds: 20
+          timeout_seconds: 90
           retry_wait_seconds: 1
           max_attempts: 3
           shell: bash
@@ -413,7 +413,7 @@ jobs:
         if: ${{ inputs.e2e_tag && inputs.retry_push_to_registry }}
         uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 1
+          timeout_seconds: 90
           retry_wait_seconds: 1
           max_attempts: 3
           shell: bash

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -224,7 +224,7 @@ jobs:
     concurrency: release
     runs-on: ubuntu-latest
     if: ${{ !inputs.template_repo && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') }}
-    timeout-minutes: 20
+    timeout-minutes: 25
     env:
       registry: cr.yandex/${{ inputs.registry_id }}
       e2e-image: ${{ inputs.e2e_image }}
@@ -376,7 +376,7 @@ jobs:
         if: ${{ inputs.use_k8_deploy_process && inputs.retry_push_to_registry }}
         uses: nick-fields/retry@v2
         with:
-          timeout_seconds: 600
+          timeout_seconds: 20
           retry_wait_seconds: 1
           max_attempts: 3
           shell: bash
@@ -413,7 +413,7 @@ jobs:
         if: ${{ inputs.e2e_tag && inputs.retry_push_to_registry }}
         uses: nick-fields/retry@v2
         with:
-          timeout_seconds: 600
+          timeout_minutes: 1
           retry_wait_seconds: 1
           max_attempts: 3
           shell: bash


### PR DESCRIPTION
Поправила таймауты на основе 3-ёх успешных пайплайнов:

**"Push release docker image to registry with retry"** - 16s, 13s, 13s = 20s
**"Push e2e docker image to registry with retry"** - 56s, 32s, 46s = 1m

Подняла общий таймаут для релиза с 20 до 25 минут на глаз на основе неуспешных 3-ёх пайплайнов с шагом релиза **"Push e2e docker image to registry with retry"** - 7m 44s, 5m 11s, 10m 15s -  5 минут будет доп. запас 
