### PR TITLE
fix: add variable for jobs timeout

### DIFF
--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -8,6 +8,16 @@ on:
         default: "18.x"
         required: false
         type: string
+      checking_timeout_minutes:
+        description: "checking timeout minutes"
+        default: 15
+        required: false
+        type: number
+      release_timeout_minutes:
+        description: "release timeout minutes"
+        default: 25
+        required: false
+        type: number
       typechecking:
         description: "True if need to run check-types"
         default: false
@@ -129,7 +139,7 @@ on:
 jobs:
   checking:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: ${{ inputs.checking_timeout_minutes }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -219,7 +229,7 @@ jobs:
     concurrency: release
     runs-on: ubuntu-latest
     if: ${{ !inputs.template_repo && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') }}
-    timeout-minutes: 25
+    timeout-minutes: ${{ inputs.release_timeout_minutes }}
     env:
       registry: cr.yandex/${{ inputs.registry_id }}
       e2e-image: ${{ inputs.e2e_image }}


### PR DESCRIPTION
из тикета в саппорте https://mindbox.slack.com/archives/C03PMP0UCBZ/p1688389982417399
Решили что будет норм добавить переменные таймауты для джоб,  что-бы мкф могли подстраивать под себя