### PR TITLE
fix: remove grep filters

### DIFF
--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -434,7 +434,6 @@ jobs:
             -e CYPRESS_username=${{ secrets.cypress_login }} \
             -e CYPRESS_password=${{ secrets.cypress_pass }} \
             -e CYPRESS_grepTags="@smoke" \
-            -e CYPRESS_grepFilterSpecs=true \
             -e CYPRESS_grepOmitFiltered=true \
             -v $(pwd)/cypress/${{ matrix.project }}/videos:/e2e/cypress/videos \
             -v $(pwd)/cypress/${{ matrix.project }}/screenshots:/e2e/cypress/screenshots \


### PR DESCRIPTION
 - сломался пакет @cypress/grep из-за него не могут стартовать тесты frontend-staff в core-v2
 - Временно удаляем переменную,  пока [grepFilters](https://github.com/cypress-io/cypress/issues/27216) не починят 