### PR TITLE
Fix set-output

### DIFF
--- a/ensure-bump/action.yaml
+++ b/ensure-bump/action.yaml
@@ -16,9 +16,9 @@ runs:
       run: |
         if git diff --name-only HEAD^ HEAD | grep -q "${{ inputs.abstractionsPath }}"
         then
-          echo "::set-output name=changed::true"
+          echo "changed=true" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=changed::false"
+          echo "changed=false" >> $GITHUB_OUTPUT
         fi
       shell: bash
 
@@ -34,9 +34,9 @@ runs:
       run: |
         if git diff HEAD^ HEAD -- "${{ inputs.buildPropsPath }}" | grep -q "${{ steps.xml.outputs.info }}"
         then
-        echo "::set-output name=changed::true"
+        echo "changed=true" >> $GITHUB_OUTPUT
         else
-        echo "::set-output name=changed::false"
+        echo "changed=false" >> $GITHUB_OUTPUT
         fi
       shell: bash  
 


### PR DESCRIPTION
Когда делал ПР в либу локализации (там используется этот экшон) - увидел предупреждение, решил поправить

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/