### PR TITLE
fix: node version with npm 9+

### DIFF
--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       node_version:
         description: "Node.js version"
-        default: "18.x"
+        default: "18.18.2"
         required: false
         type: string
       checking_timeout_minutes:

--- a/.github/workflows/frontend_deploy_hot_testing.yml
+++ b/.github/workflows/frontend_deploy_hot_testing.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       node_version:
         description: "Node.js version"
-        default: "18.x"
+        default: "18.18.2"
         required: false
         type: string
       registry_id:

--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       node_version:
         description: "Node.js version"
-        default: "18.x"
+        default: "18.18.2"
         required: false
         type: string
       e2e-timeout:

--- a/.github/workflows/frontend_library_ci.yml
+++ b/.github/workflows/frontend_library_ci.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       node_version:
         description: "Node.js version"
-        default: "18.x"
+        default: "18.18.2"
         required: false
         type: string
       typechecking:


### PR DESCRIPTION
Фиксируем версию ноды таким образом, чтобы у нас не стрелял иногда npm 10, переход надо делать явным.
Подарок в последней минорке [ноды](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md#18.19.0)