### PR TITLE
Fix NotifyBumpPackages - add integration uri argument

### DIFF
--- a/notify-bump-packages/NotifyBumpPackages/ActionInputs.cs
+++ b/notify-bump-packages/NotifyBumpPackages/ActionInputs.cs
@@ -9,10 +9,10 @@ public class ActionInputs
         HelpText = "Github token")]
     public string Token { get; set; } = null!;
 
-    [Option('t', "team",
+    [Option('i', "integration-uri",
         Required = true,
-        HelpText = "Team to route warning message")]
-    public string Team { get; set; } = null!;
+        HelpText = "Grafana integration URI")]
+    public string IntegrationURI { get; set; } = null!;
 
     [Option('a', "authors",
         Required = true,

--- a/notify-bump-packages/NotifyBumpPackages/BumpPackagesNotifier.cs
+++ b/notify-bump-packages/NotifyBumpPackages/BumpPackagesNotifier.cs
@@ -12,7 +12,6 @@ public class BumpPackagesNotifier
     private readonly IGitHubClient _githubClient;
     private readonly IEnumerable<string> _authors;
     private readonly int _timeout;
-    private readonly string _team;
     private readonly int _retries;
     private readonly string _grafanaUri;
     private readonly HttpClient _httpClient;
@@ -23,14 +22,12 @@ public class BumpPackagesNotifier
         IEnumerable<string> repositories,
         IEnumerable<string> authors,
         int timeout,
-        string team,
         int retries,
         string grafanaUri)
     {
         _repositories = repositories;
         _authors = authors;
         _timeout = timeout;
-        _team = team;
         _retries = retries;
         _grafanaUri = grafanaUri;
         _httpClient = httpClient;
@@ -41,7 +38,6 @@ public class BumpPackagesNotifier
     {
         var _messageToGrafana = new MessageToGrafanaDto()
         {
-            Team = _team,
             PullRequests = new List<ForgottenPullRequestDto>()
         };
 

--- a/notify-bump-packages/NotifyBumpPackages/MessageToGrafanaDto.cs
+++ b/notify-bump-packages/NotifyBumpPackages/MessageToGrafanaDto.cs
@@ -4,9 +4,6 @@ namespace NotifyBumpPackages;
 
 public class MessageToGrafanaDto
 {
-    [JsonPropertyName("team")]
-    public string Team { get; set; } = null!;
-
     [JsonPropertyName("alert_uid")]
     public Guid AlertUid { get; set; } = Guid.NewGuid();
 

--- a/notify-bump-packages/NotifyBumpPackages/Program.cs
+++ b/notify-bump-packages/NotifyBumpPackages/Program.cs
@@ -2,9 +2,6 @@
 using NotifyBumpPackages;
 using Octokit;
 
-const string grafanaUri =
-    @"https://a-prod-us-central-0.grafana.net/integrations/v1/formatted_webhook/4kI3HQb0Tg0G7pt25YXURTvBP/";
-
 var _options = Parser.Default.ParseArguments<ActionInputs>(args).Value;
 
 var _githubClient = new GitHubClient(new ProductHeaderValue("notify-bump-packages"))
@@ -22,8 +19,7 @@ var _notifier = new BumpPackagesNotifier(
     _repositories,
     _authors,
     _options.Timeout,
-    _options.Team,
     _options.Retries,
-    grafanaUri);
+    _options.IntegrationURI);
 
 await _notifier.ScanAndNotifyAsync();

--- a/notify-bump-packages/NotifyBumpPackagesTest/BumpPackagesNotifierTests.cs
+++ b/notify-bump-packages/NotifyBumpPackagesTest/BumpPackagesNotifierTests.cs
@@ -84,13 +84,11 @@ public class BumpPackagesNotifierTests
             _repositories,
             _authors,
             1,
-            "testTeam",
             1,
             "http://localhots");
 
         await _notifier.ScanAndNotifyAsync();
 
-        Assert.AreEqual("testTeam", _request.Team);
         Assert.AreEqual(TestAuthor, _request.PullRequests[0].Author);
         Assert.AreEqual(1, _request.PullRequests.Count);
         Assert.AreEqual("t1", _request.PullRequests[0].Title);
@@ -120,7 +118,6 @@ public class BumpPackagesNotifierTests
             _repositories,
             _authors,
             1,
-            "testTeam",
             2,
             "http://localhots");
 
@@ -149,7 +146,6 @@ public class BumpPackagesNotifierTests
             _repositories,
             _authors,
             1,
-            "testTeam",
             2,
             "http://localhots");
 

--- a/notify-bump-packages/action.yml
+++ b/notify-bump-packages/action.yml
@@ -8,9 +8,9 @@ inputs:
     description:
       'Github token.'
     required: true
-  team:
+  integration-uri:
     description:
-      'Team. For routing and group in grafana.'
+      'Grafana integration URI which will receive alert messages'
     required: true
   authors:
     description:
@@ -34,8 +34,8 @@ runs:
   args:
     - '-k'
     - ${{ inputs.token }}
-    - '-t'
-    - ${{ inputs.team }}
+    - '-i'
+    - ${{ inputs.integration-uri }}
     - '-a'
     - ${{ inputs.authors }}
     - '-d'


### PR DESCRIPTION
[Задача](https://github.com/mindbox-cloud/issues-mailings/issues/2490)
[Тред с FWK](https://mindbox.loop.ru/mindbox/pl/z1rnnk4n6bfrfkh4b57etij44a)

Хотим себе в трайб такой экшн, но он не работает из-за переезда на луп - подправил логику так, чтобы все, кто хочет, могли себе это настроить и другим не мешать. Теперь надо будет вместо имени команды писать url интеграции в графане.

[Ранбук](https://www.notion.so/mindbox/1d41e12423994dabbabd4e452cc36c0f#9ef64247f66049ada41796b72f4227ba) подправлю.

Локально протестил - всё работает, [вот пруф из графаны](https://mindbox.grafana.net/a/grafana-oncall-app/alert-groups/IZUFQ2CQV6WWZ?perpage=25&search=Bump&start=1&started_at=now-30d_now).