### PR TITLE
Bump actions/download-artifact

### DIFF
--- a/yc-terraform-ci/action.yml
+++ b/yc-terraform-ci/action.yml
@@ -76,7 +76,7 @@ runs:
         node-version: 18
 
     - name: "Download Providers Artifact"
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       if: ${{ inputs.tfUseLocalSetup == 'true' }}
       with:
         name: tf-providers


### PR DESCRIPTION
[Тут](https://github.com/mindbox-cloud/github-actions/commit/17236e6be36f1fcbb528d0967b6384e066522b9c#diff-04998d12dff0b4d37917bd0b5dcc95623a4f060e3a2843d6ab4ab357afb4519c) обновили до v4 экшен сохранения артифактов, из-за этого видимо v3 версия экшена загрузки артифакта не видит его

https://mindbox.loop.ru/mindbox/pl/mda5x1pzepf7trnaj5hjihk6yy