### PR TITLE
Increase frontend node memory limit

### DIFF
--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -111,6 +111,13 @@ on:
         description: "Pipeline metrics auth token"
         required: false
 
+env:
+  # temporarily increase Node.js memory limits to support double-builds
+  # more info: https://tracker.yandex.ru/FRONTEND-4
+  # TODO remove when fully migrated to Module Federation 2
+  env:
+    NODE_OPTIONS: --max_old_space_size=4096
+
 jobs:
   checking:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Временно делаем двойную сборку фронта, поэтому нужно в 2 раза больше памяти. Из-за этого в некоторых МКФ падает сборка. Пока не мигрируем на новый вариант сборки, нужно временно увеличить память для ноды.

https://tracker.yandex.ru/FRONTEND-4