### PR TITLE
[terraform-ci-dns] fix comment

### DIFF
--- a/terraform-ci-dns/action.yml
+++ b/terraform-ci-dns/action.yml
@@ -124,8 +124,6 @@ runs:
       id: truncate-plan
       working-directory: ${{ inputs.workingDir }}
       shell: bash
-      env:
-        ACTIONS_STEP_DEBUG: false
       run: |
         plan="$(terraform show -no-color plan.tfplan)"
         plan=$(echo "$plan" | sed -r 's/^([[:blank:]]*)([-+~])/\2\1/g')
@@ -143,8 +141,6 @@ runs:
       id: create-truncated-plan-file
       working-directory: ${{ inputs.workingDir }}
       shell: bash
-      env:
-        ACTIONS_STEP_DEBUG: false
       run: |
         plan_file_name='plan.stdout'
         cat << EOF > $plan_file_name
@@ -156,6 +152,7 @@ runs:
       name: "Comment plan"
       env:
         SHOW_PLAN: "${{ steps.truncate-plan.outputs.truncated != 'true' }}"
+        ACTIONS_STEP_DEBUG: false
         CONDITION: "${{ steps.plan.outputs.planExitCode }}"
       with:
         github-token: ${{ inputs.githubToken }}

--- a/terraform-ci-dns/action.yml
+++ b/terraform-ci-dns/action.yml
@@ -4,7 +4,7 @@ inputs:
   terraformVersion:
     description: ''
     required: true
-  githubToken: 
+  githubToken:
     description: ''
     required: true
   workingDir:
@@ -120,15 +120,54 @@ runs:
       working-directory: ${{ inputs.workingDir }}
       shell: bash
 
+    - name: "Truncate plan"
+      id: truncate-plan
+      working-directory: ${{ inputs.workingDir }}
+      shell: bash
+      run: |
+        plan="$(terraform show -no-color plan.tfplan)"
+        plan=$(echo "$plan" | sed -r 's/^([[:blank:]]*)([-+~])/\2\1/g')
+        plan=$(echo "$plan" | sed -r 's/^~/!/g')
+        original_length=${#plan}
+        if (($original_length > 65536)); then truncated=true; else truncated=false; fi
+        echo "truncated=${truncated}" >> $GITHUB_OUTPUT
+        EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+        echo "stdout<<$EOF" >> $GITHUB_OUTPUT
+        echo "${plan:0:65536}" >> $GITHUB_OUTPUT
+        echo "$EOF" >> $GITHUB_OUTPUT
+
+    # for escape github debug stdout
+    - name: "Create truncated plan file"
+      id: create-truncated-plan-file
+      working-directory: ${{ inputs.workingDir }}
+      shell: bash
+      run: |
+        plan_file_name='plan.stdout'
+        cat << EOF > $plan_file_name
+        ${{ steps.truncate-plan.outputs.stdout }}
+        EOF
+        echo "plan_file_name=${plan_file_name}" >> $GITHUB_OUTPUT
+
     - uses: actions/github-script@v6
       name: "Comment plan"
       env:
         PLAN: "${{ steps.show.outputs.stdout }}"
+        SHOW_PLAN: "${{ steps.truncate-plan.outputs.truncated != 'true' }}"
         CONDITION: "${{ steps.plan.outputs.planExitCode }}"
       with:
         github-token: ${{ inputs.githubToken }}
         script: |
           if (process.env.CONDITION == "2") {
+            let planMessage;
+            if (process.env.SHOW_PLAN == "true") {
+              const { readFile } = require("fs/promises")
+              const plan = await readFile('${{ inputs.workingDir }}/${{ steps.create-truncated-plan-file.outputs.plan_file_name }}')
+              planMessage = `\`\`\`diff\n ${plan} \n\`\`\``
+            }
+            else {
+              planMessage = "Please, refer to [Github Action logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            }
+
             const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
             #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Validation 🤖${{ steps.validate.outputs.stdout }}
@@ -137,10 +176,11 @@ runs:
             <details><summary>Show Plan</summary>
 
             \`\`\`terraform\n
-            ${process.env.PLAN}
+            ${planMessage}
             \`\`\`
 
             </details>
+
             *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ inputs.workingDir }}\`, Workflow: \`${{ github.workflow }}\`*`;
             github.rest.issues.createComment({
               issue_number: context.issue.number,

--- a/terraform-ci-dns/action.yml
+++ b/terraform-ci-dns/action.yml
@@ -162,7 +162,7 @@ runs:
             if (process.env.SHOW_PLAN == "true") {
               const { readFile } = require("fs/promises")
               const plan = await readFile('${{ inputs.workingDir }}/${{ steps.create-truncated-plan-file.outputs.plan_file_name }}')
-              planMessage = `\`\`\`diff\n ${plan} \n\`\`\``
+              planMessage = `\`\`\`terraform\n ${plan} \n\`\`\``
             }
             else {
               planMessage = "Please, refer to [Github Action logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
@@ -175,9 +175,7 @@ runs:
 
             <details><summary>Show Plan</summary>
 
-            \`\`\`terraform\n
             ${planMessage}
-            \`\`\`
 
             </details>
 

--- a/terraform-ci-dns/action.yml
+++ b/terraform-ci-dns/action.yml
@@ -164,7 +164,7 @@ runs:
               planMessage = `\`\`\`terraform\n ${plan} \n\`\`\``
             }
             else {
-              planMessage = "Please, refer to [Github Action logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+              planMessage = "Plan too long for a message. Please, refer to [Github Action logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."
             }
 
             const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`

--- a/terraform-ci-dns/action.yml
+++ b/terraform-ci-dns/action.yml
@@ -124,6 +124,8 @@ runs:
       id: truncate-plan
       working-directory: ${{ inputs.workingDir }}
       shell: bash
+      env:
+        ACTIONS_STEP_DEBUG: false
       run: |
         plan="$(terraform show -no-color plan.tfplan)"
         plan=$(echo "$plan" | sed -r 's/^([[:blank:]]*)([-+~])/\2\1/g')
@@ -141,6 +143,8 @@ runs:
       id: create-truncated-plan-file
       working-directory: ${{ inputs.workingDir }}
       shell: bash
+      env:
+        ACTIONS_STEP_DEBUG: false
       run: |
         plan_file_name='plan.stdout'
         cat << EOF > $plan_file_name

--- a/terraform-ci-dns/action.yml
+++ b/terraform-ci-dns/action.yml
@@ -125,7 +125,7 @@ runs:
       working-directory: ${{ inputs.workingDir }}
       shell: bash
       run: |
-        plan="$(terraform show -no-color plan.tfplan)"
+        plan=""$(terraform show -no-color plan.tfplan | sed -r '/^::debug::/d')""
         plan=$(echo "$plan" | sed -r 's/^([[:blank:]]*)([-+~])/\2\1/g')
         plan=$(echo "$plan" | sed -r 's/^~/!/g')
         original_length=${#plan}
@@ -152,7 +152,6 @@ runs:
       name: "Comment plan"
       env:
         SHOW_PLAN: "${{ steps.truncate-plan.outputs.truncated != 'true' }}"
-        ACTIONS_STEP_DEBUG: false
         CONDITION: "${{ steps.plan.outputs.planExitCode }}"
       with:
         github-token: ${{ inputs.githubToken }}

--- a/terraform-ci-dns/action.yml
+++ b/terraform-ci-dns/action.yml
@@ -151,7 +151,6 @@ runs:
     - uses: actions/github-script@v6
       name: "Comment plan"
       env:
-        PLAN: "${{ steps.show.outputs.stdout }}"
         SHOW_PLAN: "${{ steps.truncate-plan.outputs.truncated != 'true' }}"
         CONDITION: "${{ steps.plan.outputs.planExitCode }}"
       with:


### PR DESCRIPTION
[loop](https://mindbox.loop.ru/mindbox/pl/9rm5uegpo3n1jr8ske1c789h6y)
Сейчас при слишком большом выводе terraform-plan ci падает. 
Замечено, что весь вывод почему-то оказывается в строках, начинающихся с `::debug::`. Вроде как в yandex-terraform-ci, на основании кт сделано, такой проблемы нет. Я просто вырезаю эти строки и забиваю на поиск более красивого решения