### PR TITLE
Add playwright workflow

### DIFF
--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -392,12 +392,12 @@ jobs:
           command: docker push ${{ env.registry }}/${{ env.e2e-image }}:${{ env.e2e-tag }}
 
       - name: Build e2e playwright docker image
-        if: ${{ inputs.e2e_tag_playwright != "" }}
+        if: ${{ inputs.e2e_tag_playwright }}
         run: docker build . -t ${{ env.registry }}/${{ env.image }}:${{ inputs.e2e_tag_playwright }}
         working-directory: ./playwright
 
       - name: Push e2e playwright docker image to registry with retry
-        if: ${{ inputs.e2e_tag_playwright != "" }}
+        if: ${{ inputs.e2e_tag_playwright }}
         uses: nick-fields/retry@v2
         with:
           timeout_seconds: 180

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -88,6 +88,11 @@ on:
         default: false
         required: false
         type: boolean
+      runs_on:
+        description: "What runners to use"
+        default: '["self-hosted", "frontend"]'
+        required: false
+        type: string
     secrets:
       gh_npm_registry:
         description: "A GH_NPM_REGISTRY token passed from the caller workflow"
@@ -119,7 +124,7 @@ env:
 
 jobs:
   checking:
-    runs-on: [self-hosted, frontend]
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
     timeout-minutes: ${{ inputs.checking_timeout_minutes }}
     steps:
       - name: Checkout the repository

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -73,6 +73,11 @@ on:
         default: ""
         required: false
         type: string
+      e2e_tag_playwright:
+        description: "Image tag to creating e2e tests via playwright"
+        default: ""
+        required: false
+        type: string
       commit_release_version:
         type: boolean
         description: "True if need to commit release version to package.json"
@@ -388,7 +393,7 @@ jobs:
           wget --header 'Authorization: token ${{ secrets.frontend_gha_full_token }}' https://raw.githubusercontent.com/mindbox-cloud/frontend-cypress/master/docker/Dockerfile
         working-directory: ./e2e
 
-      - name: Build e2e docker images
+      - name: Build e2e docker image
         if: ${{ inputs.e2e_tag }}
         run: docker build . -t ${{ env.registry }}/${{ env.e2e-image }}:${{ env.e2e-tag }}
         working-directory: ./e2e
@@ -402,6 +407,21 @@ jobs:
           max_attempts: 3
           shell: bash
           command: docker push ${{ env.registry }}/${{ env.e2e-image }}:${{ env.e2e-tag }}
+
+      - name: Build e2e playwright docker image
+        if: ${{ inputs.e2e_tag_playwright }}
+        run: docker build . -t ${{ env.registry }}/${{ env.image }}:${{ inputs.e2e_tag_playwright }}
+        working-directory: ./playwright
+
+      - name: Push e2e playwright docker image to registry with retry
+        if: ${{ inputs.e2e_tag_playwright }}
+        uses: nick-fields/retry@v2
+        with:
+          timeout_seconds: 180
+          retry_wait_seconds: 1
+          max_attempts: 3
+          shell: bash
+          command: docker push ${{ env.registry }}/${{ env.e2e-image }}:${{ env.e2e_tag_playwright }}
 
       - name: Post release to pipelines
         run: |

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -392,12 +392,12 @@ jobs:
           command: docker push ${{ env.registry }}/${{ env.e2e-image }}:${{ env.e2e-tag }}
 
       - name: Build e2e playwright docker image
-        if: ${{ inputs.e2e_tag_playwright }}
+        if: ${{ inputs.e2e_tag_playwright != "" }}
         run: docker build . -t ${{ env.registry }}/${{ env.image }}:${{ inputs.e2e_tag_playwright }}
         working-directory: ./playwright
 
       - name: Push e2e playwright docker image to registry with retry
-        if: ${{ inputs.e2e_tag_playwright }}
+        if: ${{ inputs.e2e_tag_playwright != "" }}
         uses: nick-fields/retry@v2
         with:
           timeout_seconds: 180

--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -491,9 +491,9 @@ jobs:
             -e CYPRESS_password=${{ secrets.cypress_pass }} \
             -e CYPRESS_grepTags="@smoke" \
             -e CYPRESS_grepOmitFiltered=true \
-            -e ADMINSITE_USERNAME=${{ secrets.e2e_adminsite_username }} \ 
+            -e ADMINSITE_USERNAME=${{ secrets.e2e_adminsite_username }} \
             -e ADMINSITE_PASSWORD=${{ secrets.e2e_adminsite_password }} \
-            -e GREP_TAGS="@smoke"
+            -e GREP_TAGS="@smoke" \
             -v $(pwd)/cypress/${{ matrix.project }}/videos:/e2e/cypress/videos \
             -v $(pwd)/cypress/${{ matrix.project }}/screenshots:/e2e/cypress/screenshots \
             cr.yandex/${{ inputs.registry_id }}/frontend-e2e:${{ matrix.project }}-latest 2>&1

--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -75,6 +75,14 @@ on:
       kube_dev_config_k8:
         description: "A SA_TOKEN_DTLN_KUBE_CDP_STAGING_MICROFRONTENDS token passed from the caller workflow for new deploy"
         required: false
+      e2e_adminsite_username:
+        description: "Username for admin site e2e test user"
+        required: false
+        default: ""
+      e2e_adminsite_password:
+        description: "Password for admin site e2e test user"
+        required: false
+        default: ""
       kube_token:
         description: "A SA_TOKEN_RU_STAGING_YC_KUBE_CDP_MIXED1_MICROFRONTENDS token passed from the caller workflow for deploy"
         required: true
@@ -87,9 +95,6 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     env:
-      retries: ${{ inputs.retries }}
-      CYPRESS_username: "${{ secrets.cypress_login }}"
-      CYPRESS_password: "${{ secrets.cypress_pass }}"
       registry: cr.yandex/${{ inputs.registry_id }}
       image: ${{ inputs.image_name }}
 
@@ -302,8 +307,6 @@ jobs:
     timeout-minutes: ${{ inputs.e2e-timeout }}
     if: ${{ always() && !cancelled() && !inputs.core_project && inputs.e2e_runner == 'playwright' }}
     env:
-      adminsite_username: "${{ secrets.cypress_login }}"
-      adminsite_password: "${{ secrets.cypress_pass }}"
       image: frontend-e2e-pr
 
     steps:
@@ -337,8 +340,8 @@ jobs:
           docker run -i \
             -e BASE_URL="https://e2e-testing-${{ env.hash_payload }}-staging.mindbox.ru" \
             -e RETRIES="${{ env.retries }}" \
-            -e ADMINSITE_USERNAME=${{ secrets.cypress_login }} \ 
-            -e ADMINSITE_PASSWORD=${{ secrets.cypress_pass }} \
+            -e ADMINSITE_USERNAME=${{ secrets.e2e_adminsite_username }} \ 
+            -e ADMINSITE_PASSWORD=${{ secrets.e2e_adminsite_password }} \
             -v $(pwd)/playwright-report:/e2e/playwright-report \
             ${{ env.image }}:${{ env.hash_payload }} 2>&1
 
@@ -490,8 +493,8 @@ jobs:
             -e CYPRESS_password=${{ secrets.cypress_pass }} \
             -e CYPRESS_grepTags="@smoke" \
             -e CYPRESS_grepOmitFiltered=true \
-            -e ADMINSITE_USERNAME=${{ secrets.cypress_login }} \ 
-            -e ADMINSITE_PASSWORD=${{ secrets.cypress_pass }} \
+            -e ADMINSITE_USERNAME=${{ secrets.e2e_adminsite_username }} \ 
+            -e ADMINSITE_PASSWORD=${{ secrets.e2e_adminsite_password }} \
             -e GREP_TAGS="@smoke"
             -v $(pwd)/cypress/${{ matrix.project }}/videos:/e2e/cypress/videos \
             -v $(pwd)/cypress/${{ matrix.project }}/screenshots:/e2e/cypress/screenshots \

--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -50,9 +50,9 @@ on:
         type: boolean
       e2e_runner:
         description: "E2E runner"
-        default: "cypress"
         required: false
         type: string
+        default: "cypress"
     secrets:
       npm_token:
         description: "A GH_NPM_REGISTRY token passed from the caller workflow"

--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -337,7 +337,7 @@ jobs:
           docker run -i \
             -e BASE_URL="https://e2e-testing-${{ env.hash_payload }}-staging.mindbox.ru" \
             -e RETRIES="${{ env.retries }}" \
-            -e ADMINSITE_USERNAME=${{ secrets.e2e_adminsite_username }} \ 
+            -e ADMINSITE_USERNAME=${{ secrets.e2e_adminsite_username }} \
             -e ADMINSITE_PASSWORD=${{ secrets.e2e_adminsite_password }} \
             -v $(pwd)/playwright-results/report:/e2e/playwright-report \
             -v $(pwd)/playwright-results/test-results:/e2e/test-results \

--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -304,7 +304,6 @@ jobs:
     env:
       adminsite_username: "${{ secrets.cypress_login }}"
       adminsite_password: "${{ secrets.cypress_pass }}"
-      registry: cr.yandex/crpo9tj76o3c7pi8i72n
       image: frontend-e2e-pr
 
     steps:
@@ -327,23 +326,9 @@ jobs:
         id: branch_and_repo_hash
         env:
           BRANCH_AND_REPO: "${{ env.repository_name }} ${{ env.ref_name }}"
-      
-      - name: Install YC
-        run: |
-          sudo curl https://storage.yandexcloud.net/yandexcloud-yc/install.sh | bash
-          sudo ln -s /home/runner/yandex-cloud/bin/yc /bin/yc
-
-      - name: Create yc profile
-        run: |
-          yc config profile create frontend-ci
-          echo '${{ secrets.CONTAINER_REGISTRY_KEY }}' >> iam_key.json | yc config set service-account-key iam_key.json
-          rm iam_key.json
-
-      - name: Authenticate in yandex registry
-        run: echo '${{ secrets.CONTAINER_REGISTRY_KEY }}' | docker login -u json_key --password-stdin cr.yandex
 
       - name: Build docker image
-        run: docker build . -t ${{ env.registry }}/${{ env.image }}:${{ env.hash_payload }}
+        run: docker build . -t ${{ env.image }}:${{ env.hash_payload }}
         working-directory: ./playwright
 
       - name: Run E2E tests on core project.
@@ -355,7 +340,7 @@ jobs:
             -e ADMINSITE_USERNAME=${{ secrets.cypress_login }} \ 
             -e ADMINSITE_PASSWORD=${{ secrets.cypress_pass }} \
             -v $(pwd)/playwright-report:/e2e/playwright-report \
-            cr.yandex/${{ inputs.registry_id }}/frontend-e2e:${{ matrix.project }}-latest 2>&1
+            ${{ env.image }}:${{ env.hash_payload }} 2>&1
 
       - name: Upload test results artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -50,9 +50,9 @@ on:
         type: boolean
       e2e_runner:
         description: "E2E runner"
+        default: "cypress"
         required: false
         type: string
-        default: "cypress"
     secrets:
       npm_token:
         description: "A GH_NPM_REGISTRY token passed from the caller workflow"
@@ -78,11 +78,9 @@ on:
       e2e_adminsite_username:
         description: "Username for admin site e2e test user"
         required: false
-        default: ""
       e2e_adminsite_password:
         description: "Password for admin site e2e test user"
         required: false
-        default: ""
       kube_token:
         description: "A SA_TOKEN_RU_STAGING_YC_KUBE_CDP_MIXED1_MICROFRONTENDS token passed from the caller workflow for deploy"
         required: true

--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -334,15 +334,15 @@ jobs:
 
       - name: Run E2E tests on not core project.
         run: |
-          [ -d ./playwright ] && mkdir -p ./playwright
-          mkdir -p ./playwright/test-results && mkdir -p ./playwright/report
+          [ -d ./playwright-results ] && mkdir -p ./playwright-results
+          mkdir -p ./playwright-results/test-results && mkdir -p ./playwright-results/report
           docker run -i \
             -e BASE_URL="https://e2e-testing-${{ env.hash_payload }}-staging.mindbox.ru" \
             -e RETRIES="${{ env.retries }}" \
             -e ADMINSITE_USERNAME=${{ secrets.e2e_adminsite_username }} \ 
             -e ADMINSITE_PASSWORD=${{ secrets.e2e_adminsite_password }} \
-            -v $(pwd)/playwright/report:/e2e/playwright-report \
-            -v $(pwd)/playwright/test-results:/e2e/test-results \
+            -v $(pwd)/playwright-results/report:/e2e/playwright-report \
+            -v $(pwd)/playwright-results/test-results:/e2e/test-results \
             ${{ env.image }}:${{ env.hash_payload }} 2>&1
 
       - name: Upload test results artifacts

--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -334,15 +334,17 @@ jobs:
         run: docker build . -t ${{ env.image }}:${{ env.hash_payload }}
         working-directory: ./playwright
 
-      - name: Run E2E tests on core project.
+      - name: Run E2E tests on not core project.
         run: |
-          [ -d ./playwright-report ] && mkdir -p ./playwright-report
+          [ -d ./playwright ] && mkdir -p ./playwright
+          mkdir -p ./playwright/test-results && mkdir -p ./playwright/report
           docker run -i \
             -e BASE_URL="https://e2e-testing-${{ env.hash_payload }}-staging.mindbox.ru" \
             -e RETRIES="${{ env.retries }}" \
             -e ADMINSITE_USERNAME=${{ secrets.e2e_adminsite_username }} \ 
             -e ADMINSITE_PASSWORD=${{ secrets.e2e_adminsite_password }} \
-            -v $(pwd)/playwright-report:/e2e/playwright-report \
+            -v $(pwd)/playwright/report:/e2e/playwright-report \
+            -v $(pwd)/playwright/test-results:/e2e/test-results \
             ${{ env.image }}:${{ env.hash_payload }} 2>&1
 
       - name: Upload test results artifacts

--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -28,6 +28,11 @@ on:
         default: "dev_new_frontend"
         required: false
         type: string
+      playwright_image_name:
+        description: "playwright e2e image name"
+        default: "dev_new_frontend"
+        required: false
+        type: string
       core_project:
         description: "True if project is frontend_core_v2"
         default: false
@@ -43,6 +48,11 @@ on:
         default: false
         required: false
         type: boolean
+      e2e_runner:
+        description: "E2E runner"
+        default: "cypress"
+        required: false
+        type: string
     secrets:
       npm_token:
         description: "A GH_NPM_REGISTRY token passed from the caller workflow"
@@ -188,7 +198,7 @@ jobs:
           echo "The DNS CNAME record for 'e2e-testing-${{ env.hash_payload }}-staging.mindbox.ru' was not created as expected."
           exit 1
 
-  e2e-tests:
+  e2e-tests-cypress:
     runs-on: [self-hosted, frontend]
     container:
       image: cr.yandex/crpo9tj76o3c7pi8i72n/cached/browsers:node-18.16.1-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1
@@ -286,6 +296,75 @@ jobs:
           path: e2e/cypress
           retention-days: 1
 
+  e2e-tests-playwright:
+    runs-on: [self-hosted, frontend]
+    needs: prepare-site
+    timeout-minutes: ${{ inputs.e2e-timeout }}
+    if: ${{ always() && !cancelled() && !inputs.core_project && inputs.e2e_runner == 'playwright' }}
+    env:
+      adminsite_username: "${{ secrets.cypress_login }}"
+      adminsite_password: "${{ secrets.cypress_pass }}"
+      registry: cr.yandex/crpo9tj76o3c7pi8i72n
+      image: frontend-e2e-pr
+
+    steps:
+      - uses: technote-space/workflow-conclusion-action@v3
+      - name: check fail
+        if: env.WORKFLOW_CONCLUSION == 'failure'
+        run: echo "previous steps are failed" && exit 1
+
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+
+      - name: Set variables
+        run: |
+          echo "ref_name=$(echo $GITHUB_HEAD_REF | tr '[A-Z]' '[a-z]')" >> $GITHUB_ENV
+          echo "repository_name=$(cat $GITHUB_EVENT_PATH | jq '.repository.name' | sed 's/\"//g')" >> $GITHUB_ENV
+        id: set_variables
+
+      - name: Get branch and repo names hash
+        run: echo "hash_payload=$(echo $BRANCH_AND_REPO | md5sum | sed 's/  -//g')"  >> $GITHUB_ENV
+        id: branch_and_repo_hash
+        env:
+          BRANCH_AND_REPO: "${{ env.repository_name }} ${{ env.ref_name }}"
+      
+      - name: Install YC
+        run: |
+          sudo curl https://storage.yandexcloud.net/yandexcloud-yc/install.sh | bash
+          sudo ln -s /home/runner/yandex-cloud/bin/yc /bin/yc
+
+      - name: Create yc profile
+        run: |
+          yc config profile create frontend-ci
+          echo '${{ secrets.CONTAINER_REGISTRY_KEY }}' >> iam_key.json | yc config set service-account-key iam_key.json
+          rm iam_key.json
+
+      - name: Authenticate in yandex registry
+        run: echo '${{ secrets.CONTAINER_REGISTRY_KEY }}' | docker login -u json_key --password-stdin cr.yandex
+
+      - name: Build docker image
+        run: docker build . -t ${{ env.registry }}/${{ env.image }}:${{ env.hash_payload }}
+        working-directory: ./playwright
+
+      - name: Run E2E tests on core project.
+        run: |
+          [ -d ./playwright-report ] && mkdir -p ./playwright-report
+          docker run -i \
+            -e BASE_URL="https://e2e-testing-${{ env.hash_payload }}-staging.mindbox.ru" \
+            -e RETRIES="${{ env.retries }}" \
+            -e ADMINSITE_USERNAME=${{ secrets.cypress_login }} \ 
+            -e ADMINSITE_PASSWORD=${{ secrets.cypress_pass }} \
+            -v $(pwd)/playwright-report:/e2e/playwright-report \
+            cr.yandex/${{ inputs.registry_id }}/frontend-e2e:${{ matrix.project }}-latest 2>&1
+
+      - name: Upload test results artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: playwright-${{ env.project_name }}
+          path: playwright-report
+          retention-days: 1
+
   core-e2e-tests-matrix:
     runs-on: ubuntu-latest
     needs: prepare-site
@@ -352,6 +431,7 @@ jobs:
           - campaigns
           - retail
           - auth-page
+          - email-editor-playwright
       max-parallel: 4
     timeout-minutes: ${{ inputs.e2e-timeout }}
     if: ${{ always() && !cancelled() && inputs.core_project }}
@@ -425,6 +505,9 @@ jobs:
             -e CYPRESS_password=${{ secrets.cypress_pass }} \
             -e CYPRESS_grepTags="@smoke" \
             -e CYPRESS_grepOmitFiltered=true \
+            -e ADMINSITE_USERNAME=${{ secrets.cypress_login }} \ 
+            -e ADMINSITE_PASSWORD=${{ secrets.cypress_pass }} \
+            -e GREP_TAGS="@smoke"
             -v $(pwd)/cypress/${{ matrix.project }}/videos:/e2e/cypress/videos \
             -v $(pwd)/cypress/${{ matrix.project }}/screenshots:/e2e/cypress/screenshots \
             cr.yandex/${{ inputs.registry_id }}/frontend-e2e:${{ matrix.project }}-latest 2>&1
@@ -441,7 +524,7 @@ jobs:
 
   post-e2e-tests:
     runs-on: ubuntu-latest
-    needs: [e2e-tests, core-e2e-tests-runner]
+    needs: [e2e-tests-cypress, e2e-tests-playwright, core-e2e-tests-runner]
     if: ${{ failure() }}
     steps:
       - name: Add comment to commit if the job has failed
@@ -452,8 +535,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   clean-up-e2e-tests:
-    needs: [e2e-tests, core-e2e-tests-runner]
-    if: ${{ always() && ( needs.e2e-tests.result == 'success' || needs.core-e2e-tests-runner.result == 'success' ) }}
+    needs: [e2e-tests-cypress, e2e-tests-playwright, core-e2e-tests-runner]
+    if: ${{ always() && (needs.e2e-tests-cypress.result == 'success' && (inputs.e2e_runner != 'playwright' || needs.e2e-tests-playwright.result == 'success') || needs.core-e2e-tests-runner.result == 'success') }}
     uses: mindbox-cloud/github-actions/.github/workflows/frontend_cleanup_testing.yml@master
     with:
       hot_testing: false


### PR DESCRIPTION
Добавил флоу для работы с Playwright
Cypress пока не трогаем, он запускается безусловно

1. Добавил создание образа с отдельным тэгом при релизе
2. Прогон тестов конструктора на playwright в ПР коры, тут же добавил нужные env'ы
3. Прогон тестов на playwright в ПР, если e2e_runner передан как playwright. При этом cypress пока все равно запускается тоже