### PR TITLE
Split cypress and playwright tasks

### DIFF
--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -28,11 +28,6 @@ on:
         default: "dev_new_frontend"
         required: false
         type: string
-      playwright_image_name:
-        description: "playwright e2e image name"
-        default: "dev_new_frontend"
-        required: false
-        type: string
       core_project:
         description: "True if project is frontend_core_v2"
         default: false
@@ -207,7 +202,7 @@ jobs:
         - /runner/.cache/Cypress:/root/.cache/Cypress
     needs: prepare-site
     timeout-minutes: ${{ inputs.e2e-timeout }}
-    if: ${{ always() && !cancelled() && !inputs.core_project }}
+    if: ${{ always() && !cancelled() && !inputs.core_project && contains(inputs.e2e_runner, 'cypress') }}
     env:
       retries: ${{ inputs.retries }}
       CYPRESS_username: "${{ secrets.cypress_login }}"
@@ -301,7 +296,7 @@ jobs:
     runs-on: [self-hosted, frontend]
     needs: prepare-site
     timeout-minutes: ${{ inputs.e2e-timeout }}
-    if: ${{ always() && !cancelled() && !inputs.core_project && inputs.e2e_runner == 'playwright' }}
+    if: ${{ always() && !cancelled() && !inputs.core_project && contains(inputs.e2e_runner, 'playwright') }}
     env:
       image: frontend-e2e-pr
 
@@ -522,7 +517,7 @@ jobs:
 
   clean-up-e2e-tests:
     needs: [e2e-tests, e2e-tests-playwright, core-e2e-tests-runner]
-    if: ${{ always() && (needs.e2e-tests.result == 'success' && (inputs.e2e_runner != 'playwright' || needs.e2e-tests-playwright.result == 'success') || needs.core-e2e-tests-runner.result == 'success') }}
+    if: ${{ always() && ((contains(inputs.e2e_runner, 'cypress') || needs.e2e-tests.result == 'success') && (contains(inputs.e2e_runner, 'playwright') || needs.e2e-tests-playwright.result == 'success') || needs.core-e2e-tests-runner.result == 'success') }}
     uses: mindbox-cloud/github-actions/.github/workflows/frontend_cleanup_testing.yml@master
     with:
       hot_testing: false

--- a/.github/workflows/frontend_e2e.yml
+++ b/.github/workflows/frontend_e2e.yml
@@ -412,7 +412,7 @@ jobs:
           - campaigns
           - retail
           - auth-page
-          - email-editor-playwright
+          - email-editor
       max-parallel: 4
     timeout-minutes: ${{ inputs.e2e-timeout }}
     if: ${{ always() && !cancelled() && inputs.core_project }}


### PR DESCRIPTION
Добавил возможность запускать e2e для cypress/playwright как раздельно, так и вместе